### PR TITLE
Add simpe dark mode to the daily page.

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -21,6 +21,22 @@
                 width: 150px; 
                 display: inline-block;
             }
+            /*Simple dark mode support based on brower detection*/
+            @media(prefers-color-scheme: dark) {
+                html {
+                    filter: invert(1) hue-rotate(180deg);
+                    background-color: #222;
+                }
+                a {
+                    color: #54E;
+                }
+                a:visited {
+                    color: #76B;
+                }
+                html img {
+                    filter: invert(1) hue-rotate(180deg);
+                }
+            }
         </style>
         <meta name="keywords" content="Fallout,Fallout 76,Daily,Challenge,Challenges,Atom,Weekly,Score,S.C.O.R.E.,Community,Seasons,Season,Legenary Run,ATLAS,Fortify,Fortifying">
     </head>


### PR DESCRIPTION
An attempt at a quick dark mode theme. uses automatic detection based on [prefers-color-scheme](https://caniuse.com/mdn-css_at-rules_media_prefers-color-scheme).

I figured I'd just do that page, and if feedback is positive this code could be moved into it's own css that all other html pages use.
Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/5424257/125970163-a4f70fb7-ddd3-4570-acdf-432b3a8a269b.png) | ![image](https://user-images.githubusercontent.com/5424257/125970174-60609eee-e5e8-49f7-b7ae-ec3d2c98b341.png)
