### PR TITLE
convert center tag to css

### DIFF
--- a/weapons.html
+++ b/weapons.html
@@ -28,13 +28,12 @@
         </style>
         <meta name="keywords" content="Fallout,Fallout 76,Weapons,Damage,Calculation,Comparison,Comparator">
     </head>
-    <body style="height: 90%">
-        <div style="text-align: center;">
-            <span style="font-size: 36px; font-weight: bold;">Fallout 76 Weapon Damage Calculator (v3.11.3)</span>
-            <br/>
-            <!--
-            <i>(Patch 44 update still in progress.)</i>
-            -->
+    <body style="height: 90%; text-align: center">
+        <span style="font-size: 36px; font-weight: bold;">Fallout 76 Weapon Damage Calculator (v3.11.3)</span>
+        <br/>
+        <!--
+        <i>(Patch 44 update still in progress.)</i>
+        -->
         <br/>
         <br/>
         <table id="parent">
@@ -136,7 +135,6 @@
                 </td>
             </tr>
         </table>
-        </div>
         <script>
             var allWeapons = new Map();
             var allEffects = new Map();

--- a/weapons.html
+++ b/weapons.html
@@ -26,7 +26,7 @@
         <meta name="keywords" content="Fallout,Fallout 76,Weapons,Damage,Calculation,Comparison,Comparator">
     </head>
     <body style="height: 90%">
-        <center>
+        <div style="text-align: center;">
             <span style="font-size: 36px; font-weight: bold;">Fallout 76 Weapon Damage Calculator (v3.11.3)</span>
             <br/>
             <!--
@@ -133,7 +133,7 @@
                 </td>
             </tr>
         </table>
-        </center>
+        </div>
         <script>
             var allWeapons = new Map();
             var allEffects = new Map();

--- a/weapons.html
+++ b/weapons.html
@@ -6,6 +6,9 @@
                 font-family: sans-serif;
                 font-size: 20px;
             }
+            #parent {
+                margin: auto;
+            }
             td {
                 padding: 1px;
             }


### PR DESCRIPTION
center tag is deprecated in html 5, this converts it into the required css to produce the same effect